### PR TITLE
更正第1.1节样例代码一处笔误

### DIFF
--- a/part010/ch01_introduction/sec1_gis/test_1_GIS.py
+++ b/part010/ch01_introduction/sec1_gis/test_1_GIS.py
@@ -76,7 +76,7 @@
 # newds = driver.CreateDataSource(extfile)
 # layernew = newds.CreateLayer('rect', None, ogr.wkbPolygon)
 # width = math.fabs(extent[1] - extent[0])
-# height = math.fabs(extent[3] - extent[3])
+# height = math.fabs(extent[3] - extent[2])
 # tw = width / 2
 # th = width / 2
 # extnew = extent[0] + tw


### PR DESCRIPTION
矩形坐标x1=400, x2=1100, y1=300, y2=600
矩形宽度=x2-x1，长度=y2-y1=600-300=300